### PR TITLE
Round Robin Feature

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -126,6 +126,7 @@ func NewClient(config *Config) *Client {
 			EnableCompression: true,
 			HandshakeTimeout:  mulch.HandshakeTimeout,
 		},
+		pools: make(map[string]*Pool),
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -157,6 +157,7 @@ func (c *Client) startOnePool(ctx context.Context) {
 	}
 
 	target := c.Config.Targets[c.target]
+	c.lastConn = time.Now()
 
 	if c.pools[target] != nil && !c.pools[target].shutdown {
 		panic("Attempt to overwrite active mulery client pool!")

--- a/client/pool.go
+++ b/client/pool.go
@@ -174,7 +174,7 @@ func (p *Pool) remove(connection *Connection) {
 			filtered = append(filtered, conn)
 		} else {
 			p.disconnects++
-			conn.Close()
+			conn.Close() //nolint:wsl
 		}
 	}
 
@@ -207,8 +207,8 @@ func (p *Pool) size() *PoolSize {
 	poolSize.LastTry = p.lastTry
 	poolSize.Active = !p.shutdown
 
-	if poolSize.LastConn = p.client.lastConn; p.shutdown {
-		poolSize.LastConn = p.lastTry
+	if poolSize.LastConn = p.lastTry; !p.shutdown && p.client.RoundRobinConfig != nil {
+		poolSize.LastConn = p.client.lastConn
 	}
 
 	for _, connection := range p.connections {

--- a/client/pool.go
+++ b/client/pool.go
@@ -204,9 +204,12 @@ func (p *Pool) size() *PoolSize {
 	poolSize := new(PoolSize)
 	poolSize.Total = len(p.connections)
 	poolSize.Disconnects = p.disconnects
-	poolSize.LastConn = p.client.lastConn
 	poolSize.LastTry = p.lastTry
 	poolSize.Active = !p.shutdown
+
+	if poolSize.LastConn = p.client.lastConn; p.shutdown {
+		poolSize.LastConn = p.lastTry
+	}
 
 	for _, connection := range p.connections {
 		switch connection.Status() {

--- a/client/pool.go
+++ b/client/pool.go
@@ -31,6 +31,7 @@ type PoolSize struct {
 	Running     int
 	Total       int
 	LastConn    time.Time
+	Active      bool
 }
 
 // StartPool creates and starts a pool in one command.
@@ -108,7 +109,6 @@ func (p *Pool) connector(ctx context.Context, now time.Time) {
 
 	if p.client.RoundRobinConfig != nil && now.Sub(p.client.lastConn) > p.client.RetryInterval {
 		defer p.client.restart(ctx)
-		p.client.Printf("Restarting tunnel to connect to next websocket target.")
 		return //nolint:wsl
 	} else if now.Sub(p.lastTry) < p.backOff {
 		return
@@ -200,6 +200,7 @@ func (p *Pool) size() *PoolSize {
 	poolSize.Total = len(p.connections)
 	poolSize.Disconnects = p.disconnects
 	poolSize.LastConn = p.lastTry
+	poolSize.Active = !p.shutdown
 
 	for _, connection := range p.connections {
 		switch connection.Status() {

--- a/client/pool.go
+++ b/client/pool.go
@@ -31,6 +31,7 @@ type PoolSize struct {
 	Running     int
 	Total       int
 	LastConn    time.Time
+	LastTry     time.Time
 	Active      bool
 }
 
@@ -203,7 +204,8 @@ func (p *Pool) size() *PoolSize {
 	poolSize := new(PoolSize)
 	poolSize.Total = len(p.connections)
 	poolSize.Disconnects = p.disconnects
-	poolSize.LastConn = p.lastTry
+	poolSize.LastConn = p.client.lastConn
+	poolSize.LastTry = p.lastTry
 	poolSize.Active = !p.shutdown
 
 	for _, connection := range p.connections {


### PR DESCRIPTION
We need our clients to pick a new tunnel if the one they're on goes down. We don't want them all connected to all our mulery servers, but we do want them to be able to connect to any of them.

This change allows us to provide a list of servers, connect to 1, and fail over sequentially down the list if they become inaccessible for a configurable period of time.

I also exposed more pool stats so we can have a better idea what's going on with a client.