### PR TITLE
Fix crash in PoolStats

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -199,7 +199,12 @@ func (c *Client) PoolStats() map[string]*PoolSize {
 	sizes := map[string]*PoolSize{}
 
 	for socket, pool := range c.pools {
-		sizes[socket] = pool.Size()
+		if pool.shutdown {
+			// Use internal method on dead pools.
+			sizes[socket] = pool.size()
+		} else {
+			sizes[socket] = pool.Size()
+		}
 	}
 
 	return sizes

--- a/client/pool.go
+++ b/client/pool.go
@@ -135,7 +135,7 @@ func (p *Pool) fillConnectionPool(ctx context.Context, now time.Time, toCreate i
 		if toCreate == 0 {
 			// Keep this up to date, or the logic will skip to the next server prematurely.
 			p.client.lastConn = now
-		} else if now.Sub(p.client.lastConn) > p.client.RetryInterval {
+		} else if len(p.connections) == 0 && now.Sub(p.client.lastConn) > p.client.RetryInterval {
 			// We need more connections and the last successful connection was too long ago.
 			// Restart and skip to the next server in the round robin target list.
 			defer p.client.restart(ctx)

--- a/client/pool.go
+++ b/client/pool.go
@@ -132,10 +132,10 @@ func (p *Pool) connector(ctx context.Context, now time.Time) {
 
 func (p *Pool) fillConnectionPool(ctx context.Context, now time.Time, toCreate int) {
 	if p.client.RoundRobinConfig != nil {
-		if toCreate == 0 {
+		if toCreate == 0 || len(p.connections) > 0 {
 			// Keep this up to date, or the logic will skip to the next server prematurely.
 			p.client.lastConn = now
-		} else if len(p.connections) == 0 && now.Sub(p.client.lastConn) > p.client.RetryInterval {
+		} else if now.Sub(p.client.lastConn) > p.client.RetryInterval {
 			// We need more connections and the last successful connection was too long ago.
 			// Restart and skip to the next server in the round robin target list.
 			defer p.client.restart(ctx)

--- a/client/pool.go
+++ b/client/pool.go
@@ -211,6 +211,10 @@ func (p *Pool) size() *PoolSize {
 		poolSize.LastConn = p.client.lastConn
 	}
 
+	if p.shutdown {
+		return poolSize
+	}
+
 	for _, connection := range p.connections {
 		switch connection.Status() {
 		case CONNECTING:


### PR DESCRIPTION
The new PoolStats function had a race and a bug where it pulled stats from dead pools that panic'd when sending data to a closed channel. This fixes both bugs.

There was also an observed problem where the round robin tunnel feature was trigger befogre it should. Premature reconnection. That's also fixed.