### PR TITLE
Remove errant return

### DIFF
--- a/client/connection.go
+++ b/client/connection.go
@@ -100,7 +100,6 @@ func (c *Connection) keepAlive() {
 			err := c.ws.WriteControl(websocket.PingMessage, []byte{}, tick.Add(keepAliveTimeout))
 			if err != nil {
 				c.pool.client.Errorf("[%s] Tunnel keep-alive failure: %v", c.id, err)
-				return
 			}
 		case status, ok := <-c.setStatus:
 			if !ok {


### PR DESCRIPTION
This return was causing channels to hang because the loop that answers them returned and stopped running. The `keepAlive()` procedure returns correctly after `serve()` returns; it should not return before serve like it was.